### PR TITLE
add error frame handling on frame parse and connection 

### DIFF
--- a/lib/rsocket/connection.rb
+++ b/lib/rsocket/connection.rb
@@ -39,8 +39,8 @@ module RSocket
         when :PAYLOAD
           receive_response(frame)
         when :ERROR
-          if defined?(error_handler)
-            error_handler(frame)
+          if defined?(handle_error)
+            handle_error(frame)
           end
         when :CANCEL
           # cancel logic

--- a/lib/rsocket/connection.rb
+++ b/lib/rsocket/connection.rb
@@ -36,8 +36,12 @@ module RSocket
           receive_setup(frame)
         when :REQUEST_RESPONSE, :REQUEST_FNF, :REQUEST_STREAM, :REQUEST_CHANNEL, :METADATA_PUSH
           receive_request(frame)
-        when :PAYLOAD, :ERROR
+        when :PAYLOAD
           receive_response(frame)
+        when :ERROR
+          if defined?(error_handler)
+            error_handler(frame)
+          end
         when :CANCEL
           # cancel logic
         when :REQUEST_N

--- a/lib/rsocket/frame.rb
+++ b/lib/rsocket/frame.rb
@@ -86,6 +86,8 @@ module RSocket
         frame = PayloadFrame.new(stream_id, flags)
       when :METADATA_PUSH
         frame = MetadataPushFrame.new
+      when :ERROR
+        frame = ErrorFrame.new(stream_id)
       else
         # type code here
       end

--- a/lib/rsocket/requester.rb
+++ b/lib/rsocket/requester.rb
@@ -57,6 +57,15 @@ module RSocket
       close_connection(true)
     end
 
+    # @param error_frame [RSocket:ErrorFrame]
+    def error_handler(error_frame)
+      err = error_frame.data.pack('C*')
+      stream_id = error_frame.stream_id
+      subject = @streams.delete(stream_id)
+      subject.on_error(err) unless subject.nil?
+      [err, subject.nil?]
+    end
+
     #@param payload_frame [RSocket:PayloadFrame]
     def receive_response(payload_frame)
       stream_id = payload_frame.stream_id

--- a/lib/rsocket/requester.rb
+++ b/lib/rsocket/requester.rb
@@ -58,7 +58,7 @@ module RSocket
     end
 
     # @param error_frame [RSocket:ErrorFrame]
-    def error_handler(error_frame)
+    def handle_error(error_frame)
       err = error_frame.data.pack('C*')
       stream_id = error_frame.stream_id
       subject = @streams.delete(stream_id)


### PR DESCRIPTION
**Patch to handle Error Frames**

- Logic to create new Error Frame if appropriate on frame.rb parse
- Added Error Frame check on connection.rb receive_frame_bytes  and a call to error_handler if defined
