### PR TITLE
parse error frame headers

### DIFF
--- a/lib/rsocket/frame.rb
+++ b/lib/rsocket/frame.rb
@@ -88,6 +88,7 @@ module RSocket
         frame = MetadataPushFrame.new
       when :ERROR
         frame = ErrorFrame.new(stream_id)
+        frame.parse_header(buffer)
       else
         # type code here
       end


### PR DESCRIPTION
Closes https://github.com/no-lodging-or-fresh-baked-cookies/ElarianGem/issues/46


How to test:

Try making a connection with invalid credentials. Without this fix, error would be `\x00\x00\x00\x03Invalid credentials`.  With the fix, the leading hex characters should be stripped out from the error.
